### PR TITLE
Fix typo in Argo CD application path

### DIFF
--- a/argocd/applications/argocd.yml
+++ b/argocd/applications/argocd.yml
@@ -7,7 +7,7 @@ spec:
   project: default
   source:
     repoURL: https://github.com/sonda-red/cluster-management
-    path: infra/argicd
+    path: infra/argocd
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc


### PR DESCRIPTION
Correct the typo in the Argo CD application path within the `argocd.yml` file.