### PR TITLE
Add FluxCD deployment configuration for kit-test

### DIFF
--- a/clusters/sonda-red/deployments.yaml
+++ b/clusters/sonda-red/deployments.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: deployment-controllers
+  namespace: flux-system
+spec:
+  interval: 1h
+  retryInterval: 1m
+  timeout: 5m
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+  path: ./deployments
+  prune: true
+  wait: true
+  decryption:
+    provider: sops
+    secretRef:
+      name: sops-age

--- a/deployments/vllm/kit-test/kit-test.yml
+++ b/deployments/vllm/kit-test/kit-test.yml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kit-test
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app.kubernetes.io/name: kit-test }
+  template:
+    metadata:
+      labels: { app.kubernetes.io/name: kit-test }
+    spec:
+      volumes:
+      - name: modelkit
+        emptyDir: {}                       # swap with a PVC if you want persistence
+      initContainers:
+      - name: kitops-init
+        image: ghcr.io/kitops-ml/kitops-init:latest
+        env:
+        - name: MODELKIT_REF
+          value: jozu.ml/jozu/llama3-8b:8B-instruct-q4_0
+        - name: UNPACK_PATH
+          value: /data
+        - name: UNPACK_FILTER
+          value: model
+        volumeMounts: [{ name: modelkit, mountPath: /data }]
+      containers:
+      - name: vllm-kit-test
+        image: intel/vllm:xpu
+        args: ["vllm","serve","/data","--host","0.0.0.0","--port","8000","--served-model-name","llama3-8b-instruct"]
+        ports: [{ containerPort: 8000 }]
+        readinessProbe:
+          httpGet: { path: /health, port: 8000 }
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        livenessProbe:
+          httpGet: { path: /health, port: 8000 }
+          initialDelaySeconds: 15
+          periodSeconds: 10
+        resources:
+          requests: { cpu: "4", memory: "16Gi", nvidia.com/gpu: 1 }
+          limits:   { cpu: "4", memory: "16Gi", nvidia.com/gpu: 1 }
+        volumeMounts: [{ name: modelkit, mountPath: /data }]
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kit-test
+spec:
+  selector: { app.kubernetes.io/name: kit-test }
+  ports: [{ name: http, port: 8000, targetPort: 8000 }]
+  type: ClusterIP

--- a/deployments/vllm/kit-test/kustomization.yaml
+++ b/deployments/vllm/kit-test/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - kit-test.yml

--- a/deployments/vllm/kustomization.yaml
+++ b/deployments/vllm/kustomization.yaml
@@ -1,0 +1,4 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - namespace.yaml

--- a/deployments/vllm/namespace.yaml
+++ b/deployments/vllm/namespace.yaml
@@ -2,4 +2,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: github 
+  name: vllm 

--- a/deployments/vllm/namespace.yaml
+++ b/deployments/vllm/namespace.yaml
@@ -1,0 +1,5 @@
+# Create namespace
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: github 


### PR DESCRIPTION
Introduce deployment controllers and kustomization for first vllm deployment, update namespace to 'vllm', and add kit-test deployment and service configurations.