### PR TITLE
Add CoreDNS custom configuration to Kustomization

### DIFF
--- a/infrastructure/core/coredns-custom.yaml
+++ b/infrastructure/core/coredns-custom.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: coredns-custom
+  namespace: kube-system
+data:
+  sonda.red.intra.server: |
+    sonda.red.intra:53 {
+        errors
+        cache 30
+        reload
+        template IN A sonda.red.intra {
+            match ".*\.sonda\.red\.intra"
+            answer "{{ .Name }} 60 IN A 192.168.1.240"
+        }
+        hosts {
+            192.168.1.240 sonda.red.intra
+            fallthrough
+        }
+    }

--- a/infrastructure/core/coredns-custom.yaml
+++ b/infrastructure/core/coredns-custom.yaml
@@ -14,7 +14,7 @@ data:
             answer "{{ .Name }} 60 IN A 192.168.1.240"
         }
         hosts {
-            192.168.1.240 sonda.red.intra
             fallthrough
+            192.168.1.240 sonda.red.intra
         }
     }

--- a/infrastructure/core/coredns-custom.yaml
+++ b/infrastructure/core/coredns-custom.yaml
@@ -13,8 +13,4 @@ data:
             match ".*\.sonda\.red\.intra"
             answer "{{ .Name }} 60 IN A 192.168.1.240"
         }
-        hosts {
-            fallthrough
-            192.168.1.240 sonda.red.intra
-        }
     }

--- a/infrastructure/core/kustomization.yaml
+++ b/infrastructure/core/kustomization.yaml
@@ -2,3 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - node-labels.yaml
+  - coredns-custom.yaml


### PR DESCRIPTION
Include a custom CoreDNS configuration in the Kustomization to enhance DNS handling for the specified domain.