### PR TITLE
Remove internal ingress resource from kustomization.yaml

### DIFF
--- a/infrastructure/harbor/kustomization.yaml
+++ b/infrastructure/harbor/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - namespace.yaml
   - helm-repository.yaml
   - helm-release.yaml
-  - internal-ingress.yaml
 configMapGenerator:
   - name: harbor-values
     files:


### PR DESCRIPTION
Eliminate the internal ingress resource from the kustomization file to streamline configuration.